### PR TITLE
replace L4 headings with definition lists

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -5,206 +5,159 @@
 ## A
 
 Accessibility
-
 : design of products, devices, services, or environments to be usable by people who experience disabilities; sometimes abbreviated as "a11y" where 11 stands for the number of letters between the first “a” and the last “y” in the word accessibility
 
 AMY
-
 : the internal database of The Carpentries; it allows the organisation to track programmatic activity including: workshops, Tnstructor Trainings, individual roles and badges, and institutional memberships
 
 
 ## B
 
 Badge
-
 : indicator of a role in The Carpentries community that requires certification; typically, a certificate will be sent by email when a badge is conferred; see also _**Certification**_
 
 Blog Post
-
 : piece of writing shared on The Carpentries website written by the community or the Core Team to share information, community developments, or teaching tips and tricks 
 
 Bonus Module
-
 : see **_Instructor Training Bonus Module_**
 
 Business Team
-
 : members of The Carpentries Core Team who work on the legal and financial aspects of the organisation and coordinate with our fiscal sponsor, Community Initiatives
 
 
 ## C
 
 Carpentries Clippings
-
 : bi-weekly newsletter sent to an opt-in email list, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations
 
 Carpentries Conversations
-
 : community discussion hosted by one of our committees or task forces to provide the community with the opportunity to learn about and discuss new developments and programs in our organisation
 
 Carpentries Incubator
-
 : GitHub organisation hosting repositories of lessons being developed by community members; new lessons can be added to the Incubator by opening an issue on [the carpentries-incubator/proposals repository](https://github.com/carpentries-incubator/proposals)
 
 Carpentries Lab
-
 : place for sharing high-quality, peer-reviewed lessons that follow best practices in pedagogy and the general teaching practices used in The Carpentries
 
 CarpentryCon
-
 : global community conference held every two years aimed at bringing The Carpentries community together for networking, knowledge and skills sharing, and collaborations around different initiatives and programs
 
 CarpentryCon @Home
-
 : CarpentryCon events held virtually; see also **_CarpentryCon_**
 
 CarpentryCon Task Force
-
 : members of the community who organise CarpentryCon
 
 CarpentryConnect
-
 : events organised by community coordinators to bring together members of a Carpentries’ subcommunity for knowledge exchange, collaboration, and networking; frequency, size and scope are determined by community members
 
 Carpentries Handbook 
-
 : collection of information on Carpentries policies and procedures, including how to lead a workshop, how to develop and maintain lessons, how to participate in an instructor training event, how to get involved in our global community, and information about Carpentries communication channels 
 
 - [The Carpentries Handbook — The Carpentries Handbook documentation](https://docs.carpentries.org/index.html)
 
 Centrally-Organised Workshops
-
 : Carpentries workshop, in which logistics and organisation is supported by The Carpentries Core Team for a fee
 
 Certification
-
 : process of earning a badge; see also **_Badge, Checkout_**
 
 Checkout
-
 : process consisting of steps to be completed after, or in addition to, a training in order to complete certification; most often, this refers to the [Instructor checkout process](https://carpentries.github.io/instructor-training/checkout/index.html), but may also refer to [steps required for Trainer certification](https://carpentries.github.io/trainer-training/01-week1_discussion_questions/index.html#trainer-checkout)
 
 Code of Conduct (CoC)
-
 : policy that describes what is expected of everyone participating in Carpentries activities
 
 Code of Conduct Committee
-
 : members of the community who keep our community friendly and welcoming by processing and responding to reports of violations of our Code of Conduct
 
 Cohort
-
 : community members who go through a program together; community members trained in any community role who are onboarded at the same time and who then work together to develop relevant community-facing resources that address specific needs
 
 Committee
-
 : group of community members appointed for a specific function (e.g., Instructor Development Committee); committees are guided by [The Carpentries Committee Policy](https://docs.carpentries.org/topic_folders/governance/committee-policy.html?highlight=committee)
 
 Community
-
 : individuals and committees who are a part of our operations, including, but not limited to: Learners, Instructors, Helpers, Maintainers, Trainers, Community Coordinators, Workshop Hosts, Member Site Contacts, Community Champions, Curriculum Advisors, Local and Regional Community Leaders, and all Committee and Task Force Members
 
 Community Calendar
-
 : Google calendar that includes all Carpentries events
 
 Community Coordinator
-
 : member of the community who serves as leader of a subcommunity and who supports the Community Development Program
 
 Community Development Program (CDP)
-
 : program supported by the Community Development Team that offers resources and services to support community leaders who are building new or sustaining existing subcommunities (i.e., community coordinators); the primary goal of the program is to improve how subcommunities are supported to maximise benefits to our community members and to ensure the long term sustainability of the organisation as we continue to grow globally
 
 Community Development Team (CDT)
-
 : members of The Carpentries Core Team who work to develop and maintain an open and welcoming community culture; develop, test and implement communication strategies, support various committees and task forces, and introduce and support initiatives to increase pathways for collaboration in our community; focus on equitable distribution of resources, opportunities and access to inclusive spaces for our community members globally
 
 Community Discussion
-
 : community call designed for everyone in the community interested in learning, educating and advocating for teaching foundational coding and data science skills globally; there are four types of Community Discussions: Pre- and Post-Workshop Discussions, Themed Discussion Sessions, Carpentries Conversations, and Regional Community Calls
 
 Community Initiatives
-
 : fiscal sponsor of The Carpentries
 
 Core Team
-
 : team members whose primary professional focus is to support the overall mission of The Carpentries on a daily basis; include employees of our fiscal sponsor, Community Initiatives, or the professional employer organisation (PEO), Velocity Global; these individuals are fully integrated into The Carpentries operational systems, attend weekly meetings, and function as part of programmatic teams
 
 Cultural Competence
-
 : state of having and applying knowledge and skill in four areas: (1) awareness of one’s own cultural worldview; (2) recognition of one’s attitudes toward cultural differences; (3) realisation  of different cultural practices and worldviews; and (4) thoughtfulness in cross-cultural interaction
 
 Curriculum
-
 : self-contained set of one or more lessons that are aimed at a given target audience and designed to be taught together in a workshop or training
 
 Curriculum Advisor
-
 : individual who volunteers to guide the development of existing lessons, maintain a broad perspective on the state of the field, and make strategic decisions about major changes to a lesson
 
 Curriculum Advisory Committee (CAC)
-
 : group of Curriculum Advisors serving a single curriculum
 
 Curriculum Development Handbook
-
 : guide to the process and infrastructure used by The Carpentries community to develop new lessons.
 
 Curriculum Module
-
 : set of resources in the curriculum addressing one topic e.g., Code of Conduct facilitation
 
 Curriculum Team
-
 : members of The Carpentries Core Team who guide and oversee curriculum development and maintenance and work closely with our Lesson Maintainers and Curriculum Advisors
 
 
 ## D
 
 Demo
-
 : see **_Teaching Demo_**
 
 Discussion Host 
-
 : member of The Carpentries community who facilitates a community discussion
 
 Diversity
-
 : individual differences (e.g., personality, language, learning preferences and life experiences) and group-social differences (e.g., race, ethnicity, class, gender, gender identity, sexual orientation, sexual identity, country of origin and ability status, as well as cultural, political, religious or other affiliations) that can be engaged in the service of learning
 
 Donor
-
 : individual who contributes financially to The Carpentries, whether one-time or on a regular basis
 
 
 ## E
 
 Editor
-
 : coordinates and oversees the open peer review of lessons in The Carpentries Lab
 
 Episode (Lesson Episode)
-
 : single page in the body of a Carpentries lesson; multiple chapters make up a lesson; a chapter does not need to be self-contained
 
 
 Equity
-
 : creation of opportunities for equal access to and participation in programs that are capable of closing participation gaps in our community
 
 Etherpad
-
 : open-source, web-based collaborative real-time editor; allows authors to edit a text document simultaneously, and access all of the participants' edits in real-time, with the ability to display each author's text in their own colour; there is also a chat box in the sidebar to allow meta communication
 
 Executive Council 
-
 : governing body of The Carpentries, to whom the Executive Director reports; comprises nine members, from The Carpentries community or others, four elected by the community, and five appointed by the Executive Council; the highest leadership body of The Carpentries project responsible for strategic and organisational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image; members of the council also serve as advocates and ambassadors for the organisation, leveraging their networks to benefit the project’s reputation and fundraising; executes these responsibilities through a combination of quarterly Executive Council meetings and regular correspondence and collaboration via email and online platforms
 
 Executive Team
-
 : members of the Core Team who proactively bring together perspectives from all individual programmatic teams and established community segments; they discuss and resolve ongoing challenges, develop and implement a shared approach to management and leadership, review and make decisions on budget, oversee and make decisions on Core Team roles and responsibilities, establish and support how the Core Team works together, oversee project work, support the development of revenue opportunities including grants, and support the Executive Director in their work with the Executive Council 
 
 
@@ -214,89 +167,69 @@ Executive Team
 ## G
 
 Governance
-
 : system by which an organisation is controlled and operates; governance of The Carpentries is undertaken by the Executive Council, to whom the Executive Director reports; see also **_Executive Council_**
 
 Green Stickies
-
 : positive feedback from the community or for the community
 
 
 ## H
 
 Handbook
-
 : see **_Carpentries Handbook_**
 
 Helper
-
 : volunteer recruited by the workshop organiser to support Carpentries workshops; support learners one-on-one if they are stuck installing software, understanding a line of code, or any other parts of the learning process; does not have to be acertified Instructor or member of The Carpentries community; see [helper checklist](https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist) for more information
 
 Host Organisation
-
 : organisation(s) responsible for organising a Carpentries event; the organisation where the event is held
 
 
 ## I
 
 Incident Response Group (IRG)
-
 : group of people who work on a specific code of conduct incident; there will be a minimum of three people from the Code of Conduct committee on each IRG
 
 Incident Response Lead
-
 : person on the Code of Conduct committee heading the Incidence Response Group (IRG); this person is appointed on a per-incident basis by the IRG
 
 Inclusion
-
 : active, intentional, and ongoing engagement of diverse people and communities that increases awareness, content knowledge, and empathic understanding of the ways we interact within (and change) our community
 
 Incubator
-
 : see **_Carpentries Incubator_**
 
 Incubator Lesson
-
 : lesson under development by the community in The Carpentries Incubator, using the Carpentries lesson infrastructure
 
 Incubator Lesson Spotlight
-
 : regular feature in The Carpentries blog and newsletter, highlighting a lesson currently under community development; the purpose is to raise the visibility of that lesson among the broader community, and to encourage community members to contribute to its further development
 
 Infrastructure Team
-
 : members of The Carpentries Core Team that ensure the development, maintenance, and compliance of all the systems that keep our organisation operating (e.g., Etherpads, lesson templates, our internal database AMY)
 
 Instructors
-
 : community members who are certified to teach Carpentries workshops after completing Instructor Training and checkout
 
 Instructor Development Committee (IDC)
-
 : committee that develops and maintains a mentorship program to support Instructors as they progress through training, teaching, curriculum development, and other community-related activities; they help promote community-building and networking by providing (virtual) spaces where Instructors from all over the world can share teaching success stories and discuss strategies for overcoming challenges
 
 Instructor Trainee
-
 : individual who is in the process of being certified as an Instructor
 
 Instructor Trainer
-
 : community member who has been trained and certified to teach Instructor Training; they also host teaching demonstrations, attend Trainer meetings, and teach Instructor Training Bonus Modules 
 
 Instructor Training
-
 : training in how to teach Carpentries workshops, including educational psychology, evidence-based teaching practices, and Carpentries-specific information; a necessary step to complete Instructor checkout and certification. See also **_Instructor Training Curriculum_**
 
 Instructor Training Bonus Module
-
 : additional optional training that may be offered to Instructors 
 
 Instructor Training Team
-
 : members of The Carpentries Core Team who support the growth and development of The Instructor Training and Trainer Training program. 
 
 Internationalisation
-
 : initiative to translate Carpentries resources into multiple languages and support the adoption of The Carpentries internationally; sometimes abbreviated as "i18n" where 18 stands for the number of letters between the first “i” and the last “n” in the word internationalisation
 
 
@@ -309,122 +242,95 @@ Internationalisation
 ## L
 
 Lab
-
 : see **_Carpentries Lab_**
 
 Lab Lesson
-
 : peer-reviewed lesson in The Carpentries Lab; lab lessons typically begin in the Incubator and enter the Lab after passing the peer review and editorial processes.
 
 Learner
-
 : anyone who participates in a Carpentries workshop
 
 Lesson
-
 : self-contained collection of episodes teaching skills within a single topic, built using the Lesson Infrastructure
 
 Lesson Developer
-
 : member of the community who creates lesson content; may use Curriculum Development Handbook as a primary resource
 
 Lesson Development Sprint
-
 : dedicated event to make progress and encourage collaboration on the development of a lesson
 
 Lesson Infrastructure
-
 : collection of software tools that are used to build, style, and validate a Carpentries lesson website; also known as The Carpentries Workbench
 
 Lesson Infrastructure Committee
-
 : members of the community who make decisions for structural changes to the lesson infrastructure to ensure that they align with our core values
 
 Lesson Maintainer
-
 : see **_Maintainer_**
 
 Lesson Program
-
 : collection of lessons which comprise one or more Carpentries workshops and the leadership guiding their development and implementation; [lesson programs are described in further detail in The Carpentries Handbook](https://www.google.com/url?q=https://docs.carpentries.org/topic_folders/governance/lesson-program-policy.html?highlight%3Dprogram%23lesson-programs&sa=D&source=docs&ust=1655288647439065&usg=AOvVaw3I5ulcHeU8MNisgeRHiiw_)
 
 Lesson Program Governance Committee
-
 : group overseeing the strategy and policies of a Lesson Program 
 
 Local Community
-
 : members of a local community within a specific geographic region
 
 Listserv
-
 : see **_Mailing List_**
 
 
 ## M
 
 Mailing List
-
 : email list you can subscribe to for receiving communications from the community; TopicBox is the platform The Carpentries uses for supporting mailing lists
 
 Maintainer
-
 : community member working to keep Carpentries lessons stable and functional
 
 Membership
-
 : see **_Member Organisation_**
 
 Member Organisation
-
 : institution committed to supporting the maintenance and growth of The Carpentries community according to the specific details outlined in each institution’s Membership Agreement or Memorandum of Agreement 
 
 Member Council
-
 : group of representatives from Member Organisations that provide feedback and ideas to the Membership Team; each Member Organisation is allocated seats on the Member Council; [updates on the Member Organisation Council (carpentries.org)](https://carpentries.org/blog/2021/08/member-organisation-council-meeting/)
 
 Membership Team
-
 : members of The Carpentries Core Team who support the growth and development of The Carpentries Membership Program
 
 Mentee
-
 : member of the Mentoring Program who is new to The Carpentries community and is supported by a Mentor
 
 Mentor
-
 : instructor who volunteers to guide small groups of mentees toward a particular outcome
 
 Mentoring Program
-
 : program supporting Instructors who are new to our community by matching them with a personal Mentor and will help Mentees gain the confidence, technical skills, and teaching skills needed to reach their goal
 
 ## N
 
 Newsletter
-
 : communication sent to an opt-in mailing list, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations; see also **_Carpentries Clippings_**
 
 
 ## O
 
 Official Lesson
-
 : single lesson within a Lesson Program that can be taught in an official Carpentries workshop
 
 
 ## P
 
 Pilot Workshop
-
 : event where a new lesson is being tested
 
 Policy
-
 : guideline adopted by The Carpentries that informs the implementation of procedures, including but not limited to, finances, infrastructure, and programming; for more information on our policies see [policies in The Carpentries handbook](https://docs.carpentries.org/topic_folders/policies/index.html)
 
 Pre- and Post-Workshop Discussion
-
 : community discussion designed for Instructors getting ready to teach or having recently taught to come to discuss their workshop with other Instructors 
 
 
@@ -434,97 +340,75 @@ Pre- and Post-Workshop Discussion
 ## R
 
 Red Stickies
-
 : constructive feedback from the community or for the community
 
 Regional Community Call
-
 : community discussion pertaining to regional community matters 
 
 Reviewer
-
 : community member providing feedback on a lesson as part of The Carpentries Lab open peer review process
 
 Roadmap
-
 : plan that defines a goal or desired outcome and includes the major steps or milestones needed to achieve it
 
 
 ## S
 
 Self-Organised Workshop
-
 : workshop that is facilitated and organised by a certified Carpentries Instructor and their local community
 
 Slack
-
 : software platform used by The Carpentries to support synchronous and asynchronous communications; channels support communications, collaboration and co-creation among a subset of community members, depending on the channel’s purpose
 
 Sponsor
-
 : organisation that has committed to supporting The Carpentries financially through the Carpentries Sponsorship program; see also **_Sponsorship Program_** 
 
 Sponsorship Program
-
 : program that allows a company, firm, or other entity to contribute financially to The Carpentries; the program was piloted in 2021-2022 with the goal of diversifying Carpentries funding sources 
 
 Strategic Plan
-
 : document used to communicate The Carpentries goals, objectives, and actions taken to achieve those goals over a five-year period
 
 Subcommunity
-
 : local, regional, or domain-specific segment of the larger Carpentries community; these groups are supported by The Carpentries Community Development Program 
 
 
 ## T
 
 Task Force
-
 : group created to explore ideas and make updates in policy, procedures and guidelines; they bring together a small group of people focused on a particular topic for a set period of time
 
 Team
-
 : group of Core Team members that work collaboratively to support a specific program area; for more information on our Teams and their work, see [Quarterly Team Projects in The Carpentries](https://carpentries.org/core-team-projects/)
 
 Teaching Demo
-
 : session where Instructor Trainees give a short demonstration of how they would teach a lesson; part of the Instructor certification process
 
 Themed Discussion Session
-
 : community discussion centred around a particular topic (e.g., teaching your first workshop, community building strategies)
 
 Tip Sheet
-
 : community resource that synthesises and summarises information; example includes our [Welcome Tip Sheet](https://carpentries.org/welcome-tip-sheet/)
 
 TopicBox
-
 : platform The Carpentries uses for supporting email mailing lists; there are numerous mailing lists you can join based on the community roles you are supporting and your interests
 
 Trainee
-
 : Individual who has registered for or attended a Carpentries Training (e.g., Instructor Training, Trainer Training) but has not yet completed certification
 
 Trainer
-
 : Community member who teaches a Carpentries Training. see **_Instructor Trainer_**
 
 Trainers Leadership
-
 : committee of Instructor Trainers responsible for community oversight and governance
 
 Trainer Training
-
 : training in how to teach Instructor Training; a necessary step to complete Trainer checkout and certification 
 
 Training
-
 : event that provides instruction (and/or training) on specific competencies, knowledge, or skills. The individuals who complete training bcome eligible for certification upon completion of the program requirements. **see _Instructor Training_**, **see _Trainer Training_**
 
 Translator
-
 : member of the community who translate our resources into multiple languages
 
 
@@ -537,19 +421,15 @@ Translator
 ## W
 
 Workshop Administrator
-
 : role within The Carpentries Core Team that supports the organisation and execution of workshops requested by members and hosts
 
 Workshop Administration Team
-
 : members of The Carpentries Core Team who develop and implement workflows to keep our workshops operating smoothly
 
 Workshop
-
 : event that is taught by Carpentries Instructors who teach the curriculum of Data Carpentry, Library Carpentry and Software Carpentry; see **_Self-Organised Workshop_** and **_Centrally-Organised Workshop_**
 
 Workshop Host
-
 : person that organises a Carpentries workshop on behalf of their institution and requests a Centrally-Organised Workshop to be coordinated by a Workshop Administrator 
 
 
@@ -568,57 +448,43 @@ Workshop Host
 ## Archived Terms
 
 Accessibility Facilitator
-
 : inactive community service role within the Community Facilitators program; accessibility facilitators would lead conversations to review, update and implement Carpentries accessibility guidelines that guide interactions in online and in-person spaces, as well as the creation of written and audio-visual content and choice of platforms
 
 Assessment Network
-
 : inactive committee that consisted of community members helping The Carpentries understand and assess the organisation’s impact
 
 Buddy
-
 : see **_Community Buddy_**
 
 Champion
-
 : community member who helped support the growth and development of The Carpentries by advocating and connecting with local communities; the Champions program is currently inactive
 
 Code of Conduct Facilitator
-
 : inactive community service role within the Community Facilitators program; community facilitators who serve as a bridge between community members at events and our Code of Conduct processes
 
 Community Buddy
-
 : member of the community who onboards new community members
 
 Communications Facilitator
-
 : community facilitator who helped translate key communications so we could share these in languages other than English across our social media channels and lead region-specific outreach campaigns
 
 Community Facilitator
-
 : inactive community service role within the Community Facilitators program; community members who were trained to use the Community Facilitators Program curriculum
 
 Community Facilitators Program
-
 : initiative in The Carpentries that sought to create new pathways for active involvement in everyday community activities by more community members; this program has been merged into the Community Development Program
 
 Feedback Facilitator
-
 : community facilitator who collected and organised feedback shared publicly and informally in our community spaces for ease of filtering, action and response 
 
 Post-Training Framework
-
 : a resource created by the Task Force to guide Community Facilitators in identifying needs in The Carpentries community that they can collaboratively work to alleviate in their cohort after their training
 
 Regional Coordinator 
-
 : member of the community who managed workshop logistics, communicated with hosts and Instructors, and responded to general inquiries
 
 Resource-Enhancement Facilitator
-
 : community facilitator who led discussions around content design to guide the publication and archiving of community-created resources in a way that makes them accessible to all, and lowers barriers to knowledge acquisition by other community members i.e. replacing sea of text with images, GIFs, videos, illustrating workflows to make them easier to understand, managing tags and their use to collate resources across Carpentries platforms, etc
 
 Technology Facilitator
-
 : community facilitator who addressed everyday ‘how-do-I’ questions that newcomers have as they collaborate with others on platforms The Carpentries uses (i.e. GitHub)

--- a/glossary.md
+++ b/glossary.md
@@ -4,208 +4,208 @@
 
 ## A
 
-#### Accessibility
+Accessibility
 
-design of products, devices, services, or environments to be usable by people who experience disabilities; sometimes abbreviated as "a11y" where 11 stands for the number of letters between the first “a” and the last “y” in the word accessibility
+: design of products, devices, services, or environments to be usable by people who experience disabilities; sometimes abbreviated as "a11y" where 11 stands for the number of letters between the first “a” and the last “y” in the word accessibility
 
-#### AMY
+AMY
 
-the internal database of The Carpentries; it allows the organisation to track programmatic activity including: workshops, Tnstructor Trainings, individual roles and badges, and institutional memberships
+: the internal database of The Carpentries; it allows the organisation to track programmatic activity including: workshops, Tnstructor Trainings, individual roles and badges, and institutional memberships
 
 
 ## B
 
-#### Badge
+Badge
 
-indicator of a role in The Carpentries community that requires certification; typically, a certificate will be sent by email when a badge is conferred; see also _**Certification**_
+: indicator of a role in The Carpentries community that requires certification; typically, a certificate will be sent by email when a badge is conferred; see also _**Certification**_
 
-#### Blog Post
+Blog Post
 
-piece of writing shared on The Carpentries website written by the community or the Core Team to share information, community developments, or teaching tips and tricks 
+: piece of writing shared on The Carpentries website written by the community or the Core Team to share information, community developments, or teaching tips and tricks 
 
-#### Bonus Module
+Bonus Module
 
-see **_Instructor Training Bonus Module_**
+: see **_Instructor Training Bonus Module_**
 
-#### Business Team
+Business Team
 
-members of The Carpentries Core Team who work on the legal and financial aspects of the organisation and coordinate with our fiscal sponsor, Community Initiatives
+: members of The Carpentries Core Team who work on the legal and financial aspects of the organisation and coordinate with our fiscal sponsor, Community Initiatives
 
 
 ## C
 
-#### Carpentries Clippings
+Carpentries Clippings
 
-bi-weekly newsletter sent to an opt-in email list, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations
+: bi-weekly newsletter sent to an opt-in email list, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations
 
-#### Carpentries Conversations
+Carpentries Conversations
 
-community discussion hosted by one of our committees or task forces to provide the community with the opportunity to learn about and discuss new developments and programs in our organisation
+: community discussion hosted by one of our committees or task forces to provide the community with the opportunity to learn about and discuss new developments and programs in our organisation
 
-#### Carpentries Incubator
+Carpentries Incubator
 
-GitHub organisation hosting repositories of lessons being developed by community members; new lessons can be added to the Incubator by opening an issue on [the carpentries-incubator/proposals repository](https://github.com/carpentries-incubator/proposals)
+: GitHub organisation hosting repositories of lessons being developed by community members; new lessons can be added to the Incubator by opening an issue on [the carpentries-incubator/proposals repository](https://github.com/carpentries-incubator/proposals)
 
-#### Carpentries Lab
+Carpentries Lab
 
-place for sharing high-quality, peer-reviewed lessons that follow best practices in pedagogy and the general teaching practices used in The Carpentries
+: place for sharing high-quality, peer-reviewed lessons that follow best practices in pedagogy and the general teaching practices used in The Carpentries
 
-#### CarpentryCon
+CarpentryCon
 
-global community conference held every two years aimed at bringing The Carpentries community together for networking, knowledge and skills sharing, and collaborations around different initiatives and programs
+: global community conference held every two years aimed at bringing The Carpentries community together for networking, knowledge and skills sharing, and collaborations around different initiatives and programs
 
-#### CarpentryCon @Home
+CarpentryCon @Home
 
-CarpentryCon events held virtually; see also **_CarpentryCon_**
+: CarpentryCon events held virtually; see also **_CarpentryCon_**
 
-#### CarpentryCon Task Force
+CarpentryCon Task Force
 
-members of the community who organise CarpentryCon
+: members of the community who organise CarpentryCon
 
-#### CarpentryConnect
+CarpentryConnect
 
-events organised by community coordinators to bring together members of a Carpentries’ subcommunity for knowledge exchange, collaboration, and networking; frequency, size and scope are determined by community members
+: events organised by community coordinators to bring together members of a Carpentries’ subcommunity for knowledge exchange, collaboration, and networking; frequency, size and scope are determined by community members
 
-#### Carpentries Handbook 
+Carpentries Handbook 
 
-collection of information on Carpentries policies and procedures, including how to lead a workshop, how to develop and maintain lessons, how to participate in an instructor training event, how to get involved in our global community, and information about Carpentries communication channels 
+: collection of information on Carpentries policies and procedures, including how to lead a workshop, how to develop and maintain lessons, how to participate in an instructor training event, how to get involved in our global community, and information about Carpentries communication channels 
 
 - [The Carpentries Handbook — The Carpentries Handbook documentation](https://docs.carpentries.org/index.html)
 
-#### Centrally-Organised Workshops
+Centrally-Organised Workshops
 
-Carpentries workshop, in which logistics and organisation is supported by The Carpentries Core Team for a fee
+: Carpentries workshop, in which logistics and organisation is supported by The Carpentries Core Team for a fee
 
-#### Certification
+Certification
 
-process of earning a badge; see also **_Badge, Checkout_**
+: process of earning a badge; see also **_Badge, Checkout_**
 
-#### Checkout
+Checkout
 
-process consisting of steps to be completed after, or in addition to, a training in order to complete certification; most often, this refers to the [Instructor checkout process](https://carpentries.github.io/instructor-training/checkout/index.html), but may also refer to [steps required for Trainer certification](https://carpentries.github.io/trainer-training/01-week1_discussion_questions/index.html#trainer-checkout)
+: process consisting of steps to be completed after, or in addition to, a training in order to complete certification; most often, this refers to the [Instructor checkout process](https://carpentries.github.io/instructor-training/checkout/index.html), but may also refer to [steps required for Trainer certification](https://carpentries.github.io/trainer-training/01-week1_discussion_questions/index.html#trainer-checkout)
 
-#### Code of Conduct (CoC)
+Code of Conduct (CoC)
 
-policy that describes what is expected of everyone participating in Carpentries activities
+: policy that describes what is expected of everyone participating in Carpentries activities
 
-#### Code of Conduct Committee
+Code of Conduct Committee
 
-members of the community who keep our community friendly and welcoming by processing and responding to reports of violations of our Code of Conduct
+: members of the community who keep our community friendly and welcoming by processing and responding to reports of violations of our Code of Conduct
 
-#### Cohort
+Cohort
 
-community members who go through a program together; community members trained in any community role who are onboarded at the same time and who then work together to develop relevant community-facing resources that address specific needs
+: community members who go through a program together; community members trained in any community role who are onboarded at the same time and who then work together to develop relevant community-facing resources that address specific needs
 
-#### Committee
+Committee
 
-group of community members appointed for a specific function (e.g., Instructor Development Committee); committees are guided by [The Carpentries Committee Policy](https://docs.carpentries.org/topic_folders/governance/committee-policy.html?highlight=committee)
+: group of community members appointed for a specific function (e.g., Instructor Development Committee); committees are guided by [The Carpentries Committee Policy](https://docs.carpentries.org/topic_folders/governance/committee-policy.html?highlight=committee)
 
-#### Community
+Community
 
-individuals and committees who are a part of our operations, including, but not limited to: Learners, Instructors, Helpers, Maintainers, Trainers, Community Coordinators, Workshop Hosts, Member Site Contacts, Community Champions, Curriculum Advisors, Local and Regional Community Leaders, and all Committee and Task Force Members
+: individuals and committees who are a part of our operations, including, but not limited to: Learners, Instructors, Helpers, Maintainers, Trainers, Community Coordinators, Workshop Hosts, Member Site Contacts, Community Champions, Curriculum Advisors, Local and Regional Community Leaders, and all Committee and Task Force Members
 
-#### Community Calendar
+Community Calendar
 
-Google calendar that includes all Carpentries events
+: Google calendar that includes all Carpentries events
 
-#### Community Coordinator
+Community Coordinator
 
-member of the community who serves as leader of a subcommunity and who supports the Community Development Program
+: member of the community who serves as leader of a subcommunity and who supports the Community Development Program
 
-#### Community Development Program (CDP)
+Community Development Program (CDP)
 
-program supported by the Community Development Team that offers resources and services to support community leaders who are building new or sustaining existing subcommunities (i.e., community coordinators); the primary goal of the program is to improve how subcommunities are supported to maximise benefits to our community members and to ensure the long term sustainability of the organisation as we continue to grow globally
+: program supported by the Community Development Team that offers resources and services to support community leaders who are building new or sustaining existing subcommunities (i.e., community coordinators); the primary goal of the program is to improve how subcommunities are supported to maximise benefits to our community members and to ensure the long term sustainability of the organisation as we continue to grow globally
 
-#### Community Development Team (CDT)
+Community Development Team (CDT)
 
-members of The Carpentries Core Team who work to develop and maintain an open and welcoming community culture; develop, test and implement communication strategies, support various committees and task forces, and introduce and support initiatives to increase pathways for collaboration in our community; focus on equitable distribution of resources, opportunities and access to inclusive spaces for our community members globally
+: members of The Carpentries Core Team who work to develop and maintain an open and welcoming community culture; develop, test and implement communication strategies, support various committees and task forces, and introduce and support initiatives to increase pathways for collaboration in our community; focus on equitable distribution of resources, opportunities and access to inclusive spaces for our community members globally
 
-#### Community Discussion
+Community Discussion
 
-community call designed for everyone in the community interested in learning, educating and advocating for teaching foundational coding and data science skills globally; there are four types of Community Discussions: Pre- and Post-Workshop Discussions, Themed Discussion Sessions, Carpentries Conversations, and Regional Community Calls
+: community call designed for everyone in the community interested in learning, educating and advocating for teaching foundational coding and data science skills globally; there are four types of Community Discussions: Pre- and Post-Workshop Discussions, Themed Discussion Sessions, Carpentries Conversations, and Regional Community Calls
 
-#### Community Initiatives
+Community Initiatives
 
-fiscal sponsor of The Carpentries
+: fiscal sponsor of The Carpentries
 
-#### Core Team
+Core Team
 
-team members whose primary professional focus is to support the overall mission of The Carpentries on a daily basis; include employees of our fiscal sponsor, Community Initiatives, or the professional employer organisation (PEO), Velocity Global; these individuals are fully integrated into The Carpentries operational systems, attend weekly meetings, and function as part of programmatic teams
+: team members whose primary professional focus is to support the overall mission of The Carpentries on a daily basis; include employees of our fiscal sponsor, Community Initiatives, or the professional employer organisation (PEO), Velocity Global; these individuals are fully integrated into The Carpentries operational systems, attend weekly meetings, and function as part of programmatic teams
 
-#### Cultural Competence
+Cultural Competence
 
-state of having and applying knowledge and skill in four areas: (1) awareness of one’s own cultural worldview; (2) recognition of one’s attitudes toward cultural differences; (3) realisation  of different cultural practices and worldviews; and (4) thoughtfulness in cross-cultural interaction
+: state of having and applying knowledge and skill in four areas: (1) awareness of one’s own cultural worldview; (2) recognition of one’s attitudes toward cultural differences; (3) realisation  of different cultural practices and worldviews; and (4) thoughtfulness in cross-cultural interaction
 
-#### Curriculum
+Curriculum
 
-self-contained set of one or more lessons that are aimed at a given target audience and designed to be taught together in a workshop or training
+: self-contained set of one or more lessons that are aimed at a given target audience and designed to be taught together in a workshop or training
 
-#### Curriculum Advisor
+Curriculum Advisor
 
-individual who volunteers to guide the development of existing lessons, maintain a broad perspective on the state of the field, and make strategic decisions about major changes to a lesson
+: individual who volunteers to guide the development of existing lessons, maintain a broad perspective on the state of the field, and make strategic decisions about major changes to a lesson
 
-#### Curriculum Advisory Committee (CAC)
+Curriculum Advisory Committee (CAC)
 
-group of Curriculum Advisors serving a single curriculum
+: group of Curriculum Advisors serving a single curriculum
 
-#### Curriculum Development Handbook
+Curriculum Development Handbook
 
-guide to the process and infrastructure used by The Carpentries community to develop new lessons.
+: guide to the process and infrastructure used by The Carpentries community to develop new lessons.
 
-#### Curriculum Module
+Curriculum Module
 
-set of resources in the curriculum addressing one topic e.g., Code of Conduct facilitation
+: set of resources in the curriculum addressing one topic e.g., Code of Conduct facilitation
 
-#### Curriculum Team
+Curriculum Team
 
-members of The Carpentries Core Team who guide and oversee curriculum development and maintenance and work closely with our Lesson Maintainers and Curriculum Advisors
+: members of The Carpentries Core Team who guide and oversee curriculum development and maintenance and work closely with our Lesson Maintainers and Curriculum Advisors
 
 
 ## D
 
-#### Demo
+Demo
 
-see **_Teaching Demo_**
+: see **_Teaching Demo_**
 
-#### Discussion Host 
+Discussion Host 
 
-member of The Carpentries community who facilitates a community discussion
+: member of The Carpentries community who facilitates a community discussion
 
-#### Diversity
+Diversity
 
-individual differences (e.g., personality, language, learning preferences and life experiences) and group-social differences (e.g., race, ethnicity, class, gender, gender identity, sexual orientation, sexual identity, country of origin and ability status, as well as cultural, political, religious or other affiliations) that can be engaged in the service of learning
+: individual differences (e.g., personality, language, learning preferences and life experiences) and group-social differences (e.g., race, ethnicity, class, gender, gender identity, sexual orientation, sexual identity, country of origin and ability status, as well as cultural, political, religious or other affiliations) that can be engaged in the service of learning
 
-#### Donor
+Donor
 
-individual who contributes financially to The Carpentries, whether one-time or on a regular basis
+: individual who contributes financially to The Carpentries, whether one-time or on a regular basis
 
 
 ## E
 
-#### Editor
+Editor
 
-coordinates and oversees the open peer review of lessons in The Carpentries Lab
+: coordinates and oversees the open peer review of lessons in The Carpentries Lab
 
-#### Episode (Lesson Episode)
+Episode (Lesson Episode)
 
-single page in the body of a Carpentries lesson; multiple chapters make up a lesson; a chapter does not need to be self-contained
+: single page in the body of a Carpentries lesson; multiple chapters make up a lesson; a chapter does not need to be self-contained
 
 
-#### Equity
+Equity
 
-creation of opportunities for equal access to and participation in programs that are capable of closing participation gaps in our community
+: creation of opportunities for equal access to and participation in programs that are capable of closing participation gaps in our community
 
-#### Etherpad
+Etherpad
 
-open-source, web-based collaborative real-time editor; allows authors to edit a text document simultaneously, and access all of the participants' edits in real-time, with the ability to display each author's text in their own colour; there is also a chat box in the sidebar to allow meta communication
+: open-source, web-based collaborative real-time editor; allows authors to edit a text document simultaneously, and access all of the participants' edits in real-time, with the ability to display each author's text in their own colour; there is also a chat box in the sidebar to allow meta communication
 
-#### Executive Council 
+Executive Council 
 
-governing body of The Carpentries, to whom the Executive Director reports; comprises nine members, from The Carpentries community or others, four elected by the community, and five appointed by the Executive Council; the highest leadership body of The Carpentries project responsible for strategic and organisational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image; members of the council also serve as advocates and ambassadors for the organisation, leveraging their networks to benefit the project’s reputation and fundraising; executes these responsibilities through a combination of quarterly Executive Council meetings and regular correspondence and collaboration via email and online platforms
+: governing body of The Carpentries, to whom the Executive Director reports; comprises nine members, from The Carpentries community or others, four elected by the community, and five appointed by the Executive Council; the highest leadership body of The Carpentries project responsible for strategic and organisational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image; members of the council also serve as advocates and ambassadors for the organisation, leveraging their networks to benefit the project’s reputation and fundraising; executes these responsibilities through a combination of quarterly Executive Council meetings and regular correspondence and collaboration via email and online platforms
 
-#### Executive Team
+Executive Team
 
-members of the Core Team who proactively bring together perspectives from all individual programmatic teams and established community segments; they discuss and resolve ongoing challenges, develop and implement a shared approach to management and leadership, review and make decisions on budget, oversee and make decisions on Core Team roles and responsibilities, establish and support how the Core Team works together, oversee project work, support the development of revenue opportunities including grants, and support the Executive Director in their work with the Executive Council 
+: members of the Core Team who proactively bring together perspectives from all individual programmatic teams and established community segments; they discuss and resolve ongoing challenges, develop and implement a shared approach to management and leadership, review and make decisions on budget, oversee and make decisions on Core Team roles and responsibilities, establish and support how the Core Team works together, oversee project work, support the development of revenue opportunities including grants, and support the Executive Director in their work with the Executive Council 
 
 
 ## F
@@ -213,91 +213,91 @@ members of the Core Team who proactively bring together perspectives from all in
 
 ## G
 
-#### Governance
+Governance
 
-system by which an organisation is controlled and operates; governance of The Carpentries is undertaken by the Executive Council, to whom the Executive Director reports; see also **_Executive Council_**
+: system by which an organisation is controlled and operates; governance of The Carpentries is undertaken by the Executive Council, to whom the Executive Director reports; see also **_Executive Council_**
 
-#### Green Stickies
+Green Stickies
 
-positive feedback from the community or for the community
+: positive feedback from the community or for the community
 
 
 ## H
 
-#### Handbook
+Handbook
 
-see **_Carpentries Handbook_**
+: see **_Carpentries Handbook_**
 
-#### Helper
+Helper
 
-volunteer recruited by the workshop organiser to support Carpentries workshops; support learners one-on-one if they are stuck installing software, understanding a line of code, or any other parts of the learning process; does not have to be acertified Instructor or member of The Carpentries community; see [helper checklist](https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist) for more information
+: volunteer recruited by the workshop organiser to support Carpentries workshops; support learners one-on-one if they are stuck installing software, understanding a line of code, or any other parts of the learning process; does not have to be acertified Instructor or member of The Carpentries community; see [helper checklist](https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist) for more information
 
-#### Host Organisation
+Host Organisation
 
-organisation(s) responsible for organising a Carpentries event; the organisation where the event is held
+: organisation(s) responsible for organising a Carpentries event; the organisation where the event is held
 
 
 ## I
 
-#### Incident Response Group (IRG)
+Incident Response Group (IRG)
 
-group of people who work on a specific code of conduct incident; there will be a minimum of three people from the Code of Conduct committee on each IRG
+: group of people who work on a specific code of conduct incident; there will be a minimum of three people from the Code of Conduct committee on each IRG
 
-#### Incident Response Lead
+Incident Response Lead
 
-person on the Code of Conduct committee heading the Incidence Response Group (IRG); this person is appointed on a per-incident basis by the IRG
+: person on the Code of Conduct committee heading the Incidence Response Group (IRG); this person is appointed on a per-incident basis by the IRG
 
-#### Inclusion
+Inclusion
 
-active, intentional, and ongoing engagement of diverse people and communities that increases awareness, content knowledge, and empathic understanding of the ways we interact within (and change) our community
+: active, intentional, and ongoing engagement of diverse people and communities that increases awareness, content knowledge, and empathic understanding of the ways we interact within (and change) our community
 
-#### Incubator
+Incubator
 
-see **_Carpentries Incubator_**
+: see **_Carpentries Incubator_**
 
-#### Incubator Lesson
+Incubator Lesson
 
-lesson under development by the community in The Carpentries Incubator, using the Carpentries lesson infrastructure
+: lesson under development by the community in The Carpentries Incubator, using the Carpentries lesson infrastructure
 
-#### Incubator Lesson Spotlight
+Incubator Lesson Spotlight
 
-regular feature in The Carpentries blog and newsletter, highlighting a lesson currently under community development; the purpose is to raise the visibility of that lesson among the broader community, and to encourage community members to contribute to its further development
+: regular feature in The Carpentries blog and newsletter, highlighting a lesson currently under community development; the purpose is to raise the visibility of that lesson among the broader community, and to encourage community members to contribute to its further development
 
-#### Infrastructure Team
+Infrastructure Team
 
-members of The Carpentries Core Team that ensure the development, maintenance, and compliance of all the systems that keep our organisation operating (e.g., Etherpads, lesson templates, our internal database AMY)
+: members of The Carpentries Core Team that ensure the development, maintenance, and compliance of all the systems that keep our organisation operating (e.g., Etherpads, lesson templates, our internal database AMY)
 
-#### Instructors
+Instructors
 
-community members who are certified to teach Carpentries workshops after completing Instructor Training and checkout
+: community members who are certified to teach Carpentries workshops after completing Instructor Training and checkout
 
-#### Instructor Development Committee (IDC)
+Instructor Development Committee (IDC)
 
-committee that develops and maintains a mentorship program to support Instructors as they progress through training, teaching, curriculum development, and other community-related activities; they help promote community-building and networking by providing (virtual) spaces where Instructors from all over the world can share teaching success stories and discuss strategies for overcoming challenges
+: committee that develops and maintains a mentorship program to support Instructors as they progress through training, teaching, curriculum development, and other community-related activities; they help promote community-building and networking by providing (virtual) spaces where Instructors from all over the world can share teaching success stories and discuss strategies for overcoming challenges
 
-#### Instructor Trainee
+Instructor Trainee
 
-individual who is in the process of being certified as an Instructor
+: individual who is in the process of being certified as an Instructor
 
-#### Instructor Trainer
+Instructor Trainer
 
-community member who has been trained and certified to teach Instructor Training; they also host teaching demonstrations, attend Trainer meetings, and teach Instructor Training Bonus Modules 
+: community member who has been trained and certified to teach Instructor Training; they also host teaching demonstrations, attend Trainer meetings, and teach Instructor Training Bonus Modules 
 
-#### Instructor Training
+Instructor Training
 
-training in how to teach Carpentries workshops, including educational psychology, evidence-based teaching practices, and Carpentries-specific information; a necessary step to complete Instructor checkout and certification. See also **_Instructor Training Curriculum_**
+: training in how to teach Carpentries workshops, including educational psychology, evidence-based teaching practices, and Carpentries-specific information; a necessary step to complete Instructor checkout and certification. See also **_Instructor Training Curriculum_**
 
-#### Instructor Training Bonus Module
+Instructor Training Bonus Module
 
-additional optional training that may be offered to Instructors 
+: additional optional training that may be offered to Instructors 
 
-#### Instructor Training Team
+Instructor Training Team
 
-members of The Carpentries Core Team who support the growth and development of The Instructor Training and Trainer Training program. 
+: members of The Carpentries Core Team who support the growth and development of The Instructor Training and Trainer Training program. 
 
-#### Internationalisation
+Internationalisation
 
-initiative to translate Carpentries resources into multiple languages and support the adoption of The Carpentries internationally; sometimes abbreviated as "i18n" where 18 stands for the number of letters between the first “i” and the last “n” in the word internationalisation
+: initiative to translate Carpentries resources into multiple languages and support the adoption of The Carpentries internationally; sometimes abbreviated as "i18n" where 18 stands for the number of letters between the first “i” and the last “n” in the word internationalisation
 
 
 ## J
@@ -308,124 +308,124 @@ initiative to translate Carpentries resources into multiple languages and suppor
 
 ## L
 
-#### Lab
+Lab
 
-see **_Carpentries Lab_**
+: see **_Carpentries Lab_**
 
-#### Lab Lesson
+Lab Lesson
 
-peer-reviewed lesson in The Carpentries Lab; lab lessons typically begin in the Incubator and enter the Lab after passing the peer review and editorial processes.
+: peer-reviewed lesson in The Carpentries Lab; lab lessons typically begin in the Incubator and enter the Lab after passing the peer review and editorial processes.
 
-#### Learner
+Learner
 
-anyone who participates in a Carpentries workshop
+: anyone who participates in a Carpentries workshop
 
-#### Lesson
+Lesson
 
-self-contained collection of episodes teaching skills within a single topic, built using the Lesson Infrastructure
+: self-contained collection of episodes teaching skills within a single topic, built using the Lesson Infrastructure
 
-#### Lesson Developer
+Lesson Developer
 
-member of the community who creates lesson content; may use Curriculum Development Handbook as a primary resource
+: member of the community who creates lesson content; may use Curriculum Development Handbook as a primary resource
 
-#### Lesson Development Sprint
+Lesson Development Sprint
 
-dedicated event to make progress and encourage collaboration on the development of a lesson
+: dedicated event to make progress and encourage collaboration on the development of a lesson
 
-#### Lesson Infrastructure
+Lesson Infrastructure
 
-collection of software tools that are used to build, style, and validate a Carpentries lesson website; also known as The Carpentries Workbench
+: collection of software tools that are used to build, style, and validate a Carpentries lesson website; also known as The Carpentries Workbench
 
-#### Lesson Infrastructure Committee
+Lesson Infrastructure Committee
 
-members of the community who make decisions for structural changes to the lesson infrastructure to ensure that they align with our core values
+: members of the community who make decisions for structural changes to the lesson infrastructure to ensure that they align with our core values
 
-#### Lesson Maintainer
+Lesson Maintainer
 
-see **_Maintainer_**
+: see **_Maintainer_**
 
-#### Lesson Program
+Lesson Program
 
-collection of lessons which comprise one or more Carpentries workshops and the leadership guiding their development and implementation; [lesson programs are described in further detail in The Carpentries Handbook](https://www.google.com/url?q=https://docs.carpentries.org/topic_folders/governance/lesson-program-policy.html?highlight%3Dprogram%23lesson-programs&sa=D&source=docs&ust=1655288647439065&usg=AOvVaw3I5ulcHeU8MNisgeRHiiw_)
+: collection of lessons which comprise one or more Carpentries workshops and the leadership guiding their development and implementation; [lesson programs are described in further detail in The Carpentries Handbook](https://www.google.com/url?q=https://docs.carpentries.org/topic_folders/governance/lesson-program-policy.html?highlight%3Dprogram%23lesson-programs&sa=D&source=docs&ust=1655288647439065&usg=AOvVaw3I5ulcHeU8MNisgeRHiiw_)
 
-#### Lesson Program Governance Committee
+Lesson Program Governance Committee
 
-group overseeing the strategy and policies of a Lesson Program 
+: group overseeing the strategy and policies of a Lesson Program 
 
-#### Local Community
+Local Community
 
-members of a local community within a specific geographic region
+: members of a local community within a specific geographic region
 
-#### Listserv
+Listserv
 
-see **_Mailing List_**
+: see **_Mailing List_**
 
 
 ## M
 
-#### Mailing List
+Mailing List
 
-email list you can subscribe to for receiving communications from the community; TopicBox is the platform The Carpentries uses for supporting mailing lists
+: email list you can subscribe to for receiving communications from the community; TopicBox is the platform The Carpentries uses for supporting mailing lists
 
-#### Maintainer
+Maintainer
 
-community member working to keep Carpentries lessons stable and functional
+: community member working to keep Carpentries lessons stable and functional
 
-#### Membership
+Membership
 
-see **_Member Organisation_**
+: see **_Member Organisation_**
 
-#### Member Organisation
+Member Organisation
 
-institution committed to supporting the maintenance and growth of The Carpentries community according to the specific details outlined in each institution’s Membership Agreement or Memorandum of Agreement 
+: institution committed to supporting the maintenance and growth of The Carpentries community according to the specific details outlined in each institution’s Membership Agreement or Memorandum of Agreement 
 
-#### Member Council
+Member Council
 
-group of representatives from Member Organisations that provide feedback and ideas to the Membership Team; each Member Organisation is allocated seats on the Member Council; [updates on the Member Organisation Council (carpentries.org)](https://carpentries.org/blog/2021/08/member-organisation-council-meeting/)
+: group of representatives from Member Organisations that provide feedback and ideas to the Membership Team; each Member Organisation is allocated seats on the Member Council; [updates on the Member Organisation Council (carpentries.org)](https://carpentries.org/blog/2021/08/member-organisation-council-meeting/)
 
-#### Membership Team
+Membership Team
 
-members of The Carpentries Core Team who support the growth and development of The Carpentries Membership Program
+: members of The Carpentries Core Team who support the growth and development of The Carpentries Membership Program
 
-#### Mentee
+Mentee
 
-member of the Mentoring Program who is new to The Carpentries community and is supported by a Mentor
+: member of the Mentoring Program who is new to The Carpentries community and is supported by a Mentor
 
-#### Mentor
+Mentor
 
-instructor who volunteers to guide small groups of mentees toward a particular outcome
+: instructor who volunteers to guide small groups of mentees toward a particular outcome
 
-#### Mentoring Program
+Mentoring Program
 
-program supporting Instructors who are new to our community by matching them with a personal Mentor and will help Mentees gain the confidence, technical skills, and teaching skills needed to reach their goal
+: program supporting Instructors who are new to our community by matching them with a personal Mentor and will help Mentees gain the confidence, technical skills, and teaching skills needed to reach their goal
 
 ## N
 
-#### Newsletter
+Newsletter
 
-communication sent to an opt-in mailing list, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations; see also **_Carpentries Clippings_**
+: communication sent to an opt-in mailing list, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations; see also **_Carpentries Clippings_**
 
 
 ## O
 
-#### Official Lesson
+Official Lesson
 
-single lesson within a Lesson Program that can be taught in an official Carpentries workshop
+: single lesson within a Lesson Program that can be taught in an official Carpentries workshop
 
 
 ## P
 
-#### Pilot Workshop
+Pilot Workshop
 
-event where a new lesson is being tested
+: event where a new lesson is being tested
 
-#### Policy
+Policy
 
-guideline adopted by The Carpentries that informs the implementation of procedures, including but not limited to, finances, infrastructure, and programming; for more information on our policies see [policies in The Carpentries handbook](https://docs.carpentries.org/topic_folders/policies/index.html)
+: guideline adopted by The Carpentries that informs the implementation of procedures, including but not limited to, finances, infrastructure, and programming; for more information on our policies see [policies in The Carpentries handbook](https://docs.carpentries.org/topic_folders/policies/index.html)
 
-#### Pre- and Post-Workshop Discussion
+Pre- and Post-Workshop Discussion
 
-community discussion designed for Instructors getting ready to teach or having recently taught to come to discuss their workshop with other Instructors 
+: community discussion designed for Instructors getting ready to teach or having recently taught to come to discuss their workshop with other Instructors 
 
 
 ## Q
@@ -433,99 +433,99 @@ community discussion designed for Instructors getting ready to teach or having r
 
 ## R
 
-#### Red Stickies
+Red Stickies
 
-constructive feedback from the community or for the community
+: constructive feedback from the community or for the community
 
-#### Regional Community Call
+Regional Community Call
 
-community discussion pertaining to regional community matters 
+: community discussion pertaining to regional community matters 
 
-#### Reviewer
+Reviewer
 
-community member providing feedback on a lesson as part of The Carpentries Lab open peer review process
+: community member providing feedback on a lesson as part of The Carpentries Lab open peer review process
 
-#### Roadmap
+Roadmap
 
-plan that defines a goal or desired outcome and includes the major steps or milestones needed to achieve it
+: plan that defines a goal or desired outcome and includes the major steps or milestones needed to achieve it
 
 
 ## S
 
-#### Self-Organised Workshop
+Self-Organised Workshop
 
-workshop that is facilitated and organised by a certified Carpentries Instructor and their local community
+: workshop that is facilitated and organised by a certified Carpentries Instructor and their local community
 
-#### Slack
+Slack
 
-software platform used by The Carpentries to support synchronous and asynchronous communications; channels support communications, collaboration and co-creation among a subset of community members, depending on the channel’s purpose
+: software platform used by The Carpentries to support synchronous and asynchronous communications; channels support communications, collaboration and co-creation among a subset of community members, depending on the channel’s purpose
 
-#### Sponsor
+Sponsor
 
-organisation that has committed to supporting The Carpentries financially through the Carpentries Sponsorship program; see also **_Sponsorship Program_** 
+: organisation that has committed to supporting The Carpentries financially through the Carpentries Sponsorship program; see also **_Sponsorship Program_** 
 
-#### Sponsorship Program
+Sponsorship Program
 
-program that allows a company, firm, or other entity to contribute financially to The Carpentries; the program was piloted in 2021-2022 with the goal of diversifying Carpentries funding sources 
+: program that allows a company, firm, or other entity to contribute financially to The Carpentries; the program was piloted in 2021-2022 with the goal of diversifying Carpentries funding sources 
 
-#### Strategic Plan
+Strategic Plan
 
-document used to communicate The Carpentries goals, objectives, and actions taken to achieve those goals over a five-year period
+: document used to communicate The Carpentries goals, objectives, and actions taken to achieve those goals over a five-year period
 
-#### Subcommunity
+Subcommunity
 
-local, regional, or domain-specific segment of the larger Carpentries community; these groups are supported by The Carpentries Community Development Program 
+: local, regional, or domain-specific segment of the larger Carpentries community; these groups are supported by The Carpentries Community Development Program 
 
 
 ## T
 
-#### Task Force
+Task Force
 
-group created to explore ideas and make updates in policy, procedures and guidelines; they bring together a small group of people focused on a particular topic for a set period of time
+: group created to explore ideas and make updates in policy, procedures and guidelines; they bring together a small group of people focused on a particular topic for a set period of time
 
-#### Team
+Team
 
-group of Core Team members that work collaboratively to support a specific program area; for more information on our Teams and their work, see [Quarterly Team Projects in The Carpentries](https://carpentries.org/core-team-projects/)
+: group of Core Team members that work collaboratively to support a specific program area; for more information on our Teams and their work, see [Quarterly Team Projects in The Carpentries](https://carpentries.org/core-team-projects/)
 
-#### Teaching Demo
+Teaching Demo
 
-session where Instructor Trainees give a short demonstration of how they would teach a lesson; part of the Instructor certification process
+: session where Instructor Trainees give a short demonstration of how they would teach a lesson; part of the Instructor certification process
 
-#### Themed Discussion Session
+Themed Discussion Session
 
-community discussion centred around a particular topic (e.g., teaching your first workshop, community building strategies)
+: community discussion centred around a particular topic (e.g., teaching your first workshop, community building strategies)
 
-#### Tip Sheet
+Tip Sheet
 
-community resource that synthesises and summarises information; example includes our [Welcome Tip Sheet](https://carpentries.org/welcome-tip-sheet/)
+: community resource that synthesises and summarises information; example includes our [Welcome Tip Sheet](https://carpentries.org/welcome-tip-sheet/)
 
-#### TopicBox
+TopicBox
 
-platform The Carpentries uses for supporting email mailing lists; there are numerous mailing lists you can join based on the community roles you are supporting and your interests
+: platform The Carpentries uses for supporting email mailing lists; there are numerous mailing lists you can join based on the community roles you are supporting and your interests
 
-#### Trainee
+Trainee
 
-Individual who has registered for or attended a Carpentries Training (e.g., Instructor Training, Trainer Training) but has not yet completed certification
+: Individual who has registered for or attended a Carpentries Training (e.g., Instructor Training, Trainer Training) but has not yet completed certification
 
-#### Trainer
+Trainer
 
-Community member who teaches a Carpentries Training. see **_Instructor Trainer_**
+: Community member who teaches a Carpentries Training. see **_Instructor Trainer_**
 
-#### Trainers Leadership
+Trainers Leadership
 
-committee of Instructor Trainers responsible for community oversight and governance
+: committee of Instructor Trainers responsible for community oversight and governance
 
-#### Trainer Training
+Trainer Training
 
-training in how to teach Instructor Training; a necessary step to complete Trainer checkout and certification 
+: training in how to teach Instructor Training; a necessary step to complete Trainer checkout and certification 
 
-#### Training
+Training
 
-event that provides instruction (and/or training) on specific competencies, knowledge, or skills. The individuals who complete training bcome eligible for certification upon completion of the program requirements. **see _Instructor Training_**, **see _Trainer Training_**
+: event that provides instruction (and/or training) on specific competencies, knowledge, or skills. The individuals who complete training bcome eligible for certification upon completion of the program requirements. **see _Instructor Training_**, **see _Trainer Training_**
 
-#### Translator
+Translator
 
-member of the community who translate our resources into multiple languages
+: member of the community who translate our resources into multiple languages
 
 
 ## U
@@ -536,21 +536,21 @@ member of the community who translate our resources into multiple languages
 
 ## W
 
-#### Workshop Administrator
+Workshop Administrator
 
-role within The Carpentries Core Team that supports the organisation and execution of workshops requested by members and hosts
+: role within The Carpentries Core Team that supports the organisation and execution of workshops requested by members and hosts
 
-#### Workshop Administration Team
+Workshop Administration Team
 
-members of The Carpentries Core Team who develop and implement workflows to keep our workshops operating smoothly
+: members of The Carpentries Core Team who develop and implement workflows to keep our workshops operating smoothly
 
-#### Workshop
+Workshop
 
-event that is taught by Carpentries Instructors who teach the curriculum of Data Carpentry, Library Carpentry and Software Carpentry; see **_Self-Organised Workshop_** and **_Centrally-Organised Workshop_**
+: event that is taught by Carpentries Instructors who teach the curriculum of Data Carpentry, Library Carpentry and Software Carpentry; see **_Self-Organised Workshop_** and **_Centrally-Organised Workshop_**
 
-#### Workshop Host
+Workshop Host
 
-person that organises a Carpentries workshop on behalf of their institution and requests a Centrally-Organised Workshop to be coordinated by a Workshop Administrator 
+: person that organises a Carpentries workshop on behalf of their institution and requests a Centrally-Organised Workshop to be coordinated by a Workshop Administrator 
 
 
 ## X
@@ -567,58 +567,58 @@ person that organises a Carpentries workshop on behalf of their institution and 
 
 ## Archived Terms
 
-#### Accessibility Facilitator
+Accessibility Facilitator
 
-inactive community service role within the Community Facilitators program; accessibility facilitators would lead conversations to review, update and implement Carpentries accessibility guidelines that guide interactions in online and in-person spaces, as well as the creation of written and audio-visual content and choice of platforms
+: inactive community service role within the Community Facilitators program; accessibility facilitators would lead conversations to review, update and implement Carpentries accessibility guidelines that guide interactions in online and in-person spaces, as well as the creation of written and audio-visual content and choice of platforms
 
-#### Assessment Network
+Assessment Network
 
-inactive committee that consisted of community members helping The Carpentries understand and assess the organisation’s impact
+: inactive committee that consisted of community members helping The Carpentries understand and assess the organisation’s impact
 
-#### Buddy
+Buddy
 
-see **_Community Buddy_**
+: see **_Community Buddy_**
 
-#### Champion
+Champion
 
-community member who helped support the growth and development of The Carpentries by advocating and connecting with local communities; the Champions program is currently inactive
+: community member who helped support the growth and development of The Carpentries by advocating and connecting with local communities; the Champions program is currently inactive
 
-#### Code of Conduct Facilitator
+Code of Conduct Facilitator
 
-inactive community service role within the Community Facilitators program; community facilitators who serve as a bridge between community members at events and our Code of Conduct processes
+: inactive community service role within the Community Facilitators program; community facilitators who serve as a bridge between community members at events and our Code of Conduct processes
 
-#### Community Buddy
+Community Buddy
 
-member of the community who onboards new community members
+: member of the community who onboards new community members
 
-#### Communications Facilitator
+Communications Facilitator
 
-community facilitator who helped translate key communications so we could share these in languages other than English across our social media channels and lead region-specific outreach campaigns
+: community facilitator who helped translate key communications so we could share these in languages other than English across our social media channels and lead region-specific outreach campaigns
 
-#### Community Facilitator
+Community Facilitator
 
-inactive community service role within the Community Facilitators program; community members who were trained to use the Community Facilitators Program curriculum
+: inactive community service role within the Community Facilitators program; community members who were trained to use the Community Facilitators Program curriculum
 
-#### Community Facilitators Program
+Community Facilitators Program
 
-initiative in The Carpentries that sought to create new pathways for active involvement in everyday community activities by more community members; this program has been merged into the Community Development Program
+: initiative in The Carpentries that sought to create new pathways for active involvement in everyday community activities by more community members; this program has been merged into the Community Development Program
 
-#### Feedback Facilitator
+Feedback Facilitator
 
-community facilitator who collected and organised feedback shared publicly and informally in our community spaces for ease of filtering, action and response 
+: community facilitator who collected and organised feedback shared publicly and informally in our community spaces for ease of filtering, action and response 
 
-#### Post-Training Framework
+Post-Training Framework
 
-a resource created by the Task Force to guide Community Facilitators in identifying needs in The Carpentries community that they can collaboratively work to alleviate in their cohort after their training
+: a resource created by the Task Force to guide Community Facilitators in identifying needs in The Carpentries community that they can collaboratively work to alleviate in their cohort after their training
 
-#### Regional Coordinator 
+Regional Coordinator 
 
-member of the community who managed workshop logistics, communicated with hosts and Instructors, and responded to general inquiries
+: member of the community who managed workshop logistics, communicated with hosts and Instructors, and responded to general inquiries
 
-#### Resource-Enhancement Facilitator
+Resource-Enhancement Facilitator
 
-community facilitator who led discussions around content design to guide the publication and archiving of community-created resources in a way that makes them accessible to all, and lowers barriers to knowledge acquisition by other community members i.e. replacing sea of text with images, GIFs, videos, illustrating workflows to make them easier to understand, managing tags and their use to collate resources across Carpentries platforms, etc
+: community facilitator who led discussions around content design to guide the publication and archiving of community-created resources in a way that makes them accessible to all, and lowers barriers to knowledge acquisition by other community members i.e. replacing sea of text with images, GIFs, videos, illustrating workflows to make them easier to understand, managing tags and their use to collate resources across Carpentries platforms, etc
 
-#### Technology Facilitator
+Technology Facilitator
 
-community facilitator who addressed everyday ‘how-do-I’ questions that newcomers have as they collaborate with others on platforms The Carpentries uses (i.e. GitHub)
+: community facilitator who addressed everyday ‘how-do-I’ questions that newcomers have as they collaborate with others on platforms The Carpentries uses (i.e. GitHub)


### PR DESCRIPTION
From <https://webaim.org/techniques/semanticstructure/#headings>:

> Headings `<h2>` through `<h6>` represent increasing degrees of
> "indentation" in our conceptual "outline". As such, it does not make
> sense to skip heading levels, such as from `<h2>` to `<h4>`, going down the
> page.

A better structure are definition/description lists:
<https://webaim.org/techniques/semanticstructure/#lists>

These are not very well-known in markdown _and it's a darn shame_
because they are so useful.

The syntax as described in
<https://pandoc.org/MANUAL.html#definition-lists> is:

```markdown
Term

: Definition
```
